### PR TITLE
Standardize OpenAPI schema to v3.0.3 and fix nullable type

### DIFF
--- a/openapi/components/schemas/StaffProfile.yaml
+++ b/openapi/components/schemas/StaffProfile.yaml
@@ -38,9 +38,8 @@ properties:
         - specialist
         - sales_advisor
   specialty:
-    type:
-      - string
-      - 'null'
+    type: string
+    nullable: true
     description: >
       Especialidad médica del miembro del personal. Solo aplica cuando
       `roles` incluye `specialist`. En caso contrario será `null`.

--- a/openapi/openapi.yaml
+++ b/openapi/openapi.yaml
@@ -1,10 +1,9 @@
-openapi: 3.1.0
+openapi: 3.0.3
 info:
   version: 1.0.0
   title: Climan API
   license:
     name: Proprietary
-    identifier: LicenseRef-Proprietary
   description: >
     API for clinic management system. Authentication is handled via Firebase
     (Google SSO). Users exchange a Firebase ID token for a short-lived platform


### PR DESCRIPTION
## What/Why/How?

This PR standardizes the OpenAPI specification format and fixes schema inconsistencies:

1. **Downgrade OpenAPI version from 3.1.0 to 3.0.3**: The 3.1.0 version introduced breaking changes in type definitions. Reverting to 3.0.3 ensures broader compatibility with OpenAPI tooling and code generators.

2. **Remove unsupported license identifier**: The `identifier` field under `license` is not supported in OpenAPI 3.0.3 and has been removed.

3. **Fix nullable type definition in StaffProfile schema**: Changed the `specialty` field from using the OpenAPI 3.1.0 syntax (`type: [string, 'null']`) to the standard 3.0.3 syntax (`type: string` with `nullable: true`). This ensures proper schema validation and code generation across tools.

## Reference

OpenAPI 3.0.3 specification: https://spec.openapis.org/oas/v3.0.3

## Testing

N/A - Schema format changes. Existing API validation tests will verify schema compliance.

## Check yourself

- [x] Code is linted
- [x] Schema follows OpenAPI 3.0.3 specification
- [x] No functional changes to API behavior

## Security

- [x] No security impact - schema format changes only

https://claude.ai/code/session_01VfNKg1BvUnpw2kgo3o8C1c